### PR TITLE
Addition of TEXT generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,11 @@ release.properties
 
 # Remove dev directory.
 dev
+*.srctrlbm
+*.srctrldb
+*.srctrlprj
+sourcetrail_dependencies
+.settings
+.classpath
+.project
+Makefile

--- a/docs/DataGenerator-batchsource.md
+++ b/docs/DataGenerator-batchsource.md
@@ -160,6 +160,7 @@ allows passing in 'mean' and 'stddev' arguments, which would be specified as:
 | SEQUENTIAL_LONG        | long      | longs in a regularly increasing sequence                            |
 | SEQUENTIAL_LONG_SKEWED | long      | SEQUENTIAL_LONG except the next number in the sequence is sometimes |
 |                        |           | replaced with a number randomly chosen from a smaller subset        |
+| TEXT                   | string    | constant / static text                                              |
 | TIMESTAMP              | timestamp | uniformly distributed timestamps between a start and end time       |
 | UUID                   | string    | random UUID                                                         |
 
@@ -185,17 +186,17 @@ Defaults to 'full'.
 
 **type:** One of 'full', 'first', 'last', 'username'. Defaults to 'full'.
 
-### RANDOM_BYTES
+#### RANDOM_BYTES
 
 **size:** Size of the byte array to generate. Defaults to 1024.
 
-### RANDOM_INT
+#### RANDOM_INT
 
 **min:** Minimum (inclusive) integer to generate. Defaults to 0.
 
 **max:** Maximum (inclusive) integer to generate. Defaults to the maximum integer value (2,147,483,647).
 
-### RANDOM_INT_SKEWED
+#### RANDOM_INT_SKEWED
 
 **min:** Minimum (inclusive) integer to generate. Defaults to 0.
 
@@ -208,13 +209,13 @@ If no value is given, it defaults to the maximum integer value (2,147,483,647).
 
 **skewMax:** Minimum (inclusive) integer to generate when generating skewed data. Defaults to 10.
 
-### RANDOM_LONG
+#### RANDOM_LONG
 
 **min:** Minimum (inclusive) long to generate. Defaults to 0.
 
 **max:** Maximum (inclusive) long to generate. Defaults to the maximum long value (2^63-1).
 
-### RANDOM_LONG_SKEWED
+#### RANDOM_LONG_SKEWED
 
 **min:** Minimum (inclusive) long to generate. Defaults to 0.
 
@@ -226,37 +227,17 @@ If no value is given, it defaults to the maximum integer value (2,147,483,647).
 
 **skewMax:** Minimum (inclusive) integer to generate when generating skewed data. Defaults to 10.
 
-### SEMI_RANDOM_STRING
+#### SEMI_RANDOM_STRING
 
 **size:** Number of characters in the string. Defaults to 100.
 
-### SEQUENTIAL_INT
+#### SEQUENTIAL_INT
 
 **start:** Number to start at. Defaults to 0.
 
 **step:** Amount to increase the number by when generating the next number in the sequence. Defaults to 1.
 
-### SEQUENTIAL_INT_SKEWED
-
-**start:** Number to start at. Defaults to 0.
-
-**step:** Amount to increase the number by when generating the next number in the sequence. Defaults to 1.
-
-**skewChance:** Percent chance to generate a skewed number. Must be between 0 and 100.
-When a skewed number is generated, the number that would otherwise be next in the sequence is skipped.
-Defaults to 10.
-
-**skewMin:** Minimum (inclusive) integer to generate when generating skewed data. Defaults to 0.
-
-**skewMax:** Minimum (inclusive) integer to generate when generating skewed data. Defaults to 10.
-
-### SEQUENTIAL_LONG
-
-**start:** Number to start at. Defaults to 0.
-
-**step:** Amount to increase the number by when generating the next number in the sequence. Defaults to 1.
-
-### SEQUENTIAL_LONG_SKEWED
+#### SEQUENTIAL_INT_SKEWED
 
 **start:** Number to start at. Defaults to 0.
 
@@ -270,7 +251,31 @@ Defaults to 10.
 
 **skewMax:** Minimum (inclusive) integer to generate when generating skewed data. Defaults to 10.
 
-### TIMESTAMP
+#### SEQUENTIAL_LONG
+
+**start:** Number to start at. Defaults to 0.
+
+**step:** Amount to increase the number by when generating the next number in the sequence. Defaults to 1.
+
+#### SEQUENTIAL_LONG_SKEWED
+
+**start:** Number to start at. Defaults to 0.
+
+**step:** Amount to increase the number by when generating the next number in the sequence. Defaults to 1.
+
+**skewChance:** Percent chance to generate a skewed number. Must be between 0 and 100.
+When a skewed number is generated, the number that would otherwise be next in the sequence is skipped.
+Defaults to 10.
+
+**skewMin:** Minimum (inclusive) integer to generate when generating skewed data. Defaults to 0.
+
+**skewMax:** Minimum (inclusive) integer to generate when generating skewed data. Defaults to 10.
+
+#### TEXT
+
+**text:** Text to insert into the field.  Defaults to empty text.
+
+#### TIMESTAMP
 
 **from:** Minimum timestamp in milliseconds to generate. Defaults to 0.
 

--- a/src/main/java/io/cdap/plugin/datagen/generator/GeneratorType.java
+++ b/src/main/java/io/cdap/plugin/datagen/generator/GeneratorType.java
@@ -43,6 +43,7 @@ public enum GeneratorType {
   SEQUENTIAL_INT_SKEWED(SequentialIntSkewedGenerator.class, SequentialIntSkewedGenerator.Config.class, Schemas.INT),
   SEQUENTIAL_LONG(SequentialLongGenerator.class, SequentialLongGenerator.Config.class, Schemas.LONG),
   SEQUENTIAL_LONG_SKEWED(SequentialLongSkewedGenerator.class, SequentialLongSkewedGenerator.Config.class, Schemas.LONG),
+  TEXT(TextGenerator.class, TextGenerator.Config.class, Schemas.STRING),
   TIMESTAMP(TimestampGenerator.class, TimestampGenerator.Config.class, Schemas.TIMESTAMP),
   UUID(UUIDGenerator.class, null, Schemas.STRING);
 

--- a/src/main/java/io/cdap/plugin/datagen/generator/TextGenerator.java
+++ b/src/main/java/io/cdap/plugin/datagen/generator/TextGenerator.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.datagen.generator;
+
+import io.cdap.plugin.datagen.DataGenerator;
+import io.cdap.plugin.datagen.GeneratorContext;
+
+/**
+ * Generates constant text.
+ * 
+ * This geneator provides constant text fields in the output.
+ */
+public class TextGenerator implements DataGenerator<String> {
+  private final Config config;
+
+  public TextGenerator(Config config) {
+    this.config = config;
+  }
+
+  @Override
+  public void initialize(GeneratorContext context) {
+  }
+
+  @Override
+  public String generate() {
+    return config.text;
+  }
+
+  /**
+   * Config.
+   */
+  public static class Config {
+    private String text;
+
+    public Config() {
+      this("");
+    }
+
+    public Config(String text) {
+      this.text = text;
+    }
+  }
+}


### PR DESCRIPTION
This pull request adds an additional field generator called "TEXT".  It is a constant / static text field and can use an argument called `text` to define what the text should be.  The use of this field type allows us to to perform unit testing within Pipelines where we can supply records of data that would otherwise have to be inserted into files.