### PR TITLE
Join on the Receiver thread on stop.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
   <properties>
     <cdap.version>6.6.0</cdap.version>
     <faker.version>1.0.2</faker.version>
+    <guava.version>13.0.1</guava.version>
     <hadoop.version>2.8.0</hadoop.version>
     <hydrator.common.version>2.8.0</hydrator.common.version>
     <junit.version>4.12</junit.version>
@@ -83,7 +84,11 @@
       <version>3.1.3</version>
       <scope>provided</scope>
     </dependency>
-
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
+    </dependency>
     <dependency>
       <groupId>io.cdap.plugin</groupId>
       <artifactId>hydrator-common</artifactId>


### PR DESCRIPTION
It is needed as after the onStop method returned, Spark will close out all resources,
hence not expecting any new block to be stored.