### PR TITLE
bump cdap, hadoop and spark version. exclude log4j dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <cdap.version>6.6.0</cdap.version>
     <faker.version>1.0.2</faker.version>
     <guava.version>13.0.1</guava.version>
-    <hadoop.version>2.8.0</hadoop.version>
+    <hadoop.version>2.10.2</hadoop.version>
     <hydrator.common.version>2.8.0</hydrator.common.version>
     <junit.version>4.12</junit.version>
   </properties>
@@ -81,7 +81,7 @@
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-streaming_2.12</artifactId>
-      <version>3.1.3</version>
+      <version>3.3.1</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -234,6 +234,12 @@
       <artifactId>cdap-unit-test</artifactId>
       <version>${cdap.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.cdap.cdap</groupId>

--- a/src/test/java/io/cdap/plugin/datagen/DataGeneratorTest.java
+++ b/src/test/java/io/cdap/plugin/datagen/DataGeneratorTest.java
@@ -35,6 +35,7 @@ import io.cdap.cdap.proto.id.ArtifactId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.test.ApplicationManager;
 import io.cdap.cdap.test.DataSetManager;
+import io.cdap.cdap.test.TestConfiguration;
 import io.cdap.cdap.test.WorkflowManager;
 import io.cdap.plugin.datagen.generator.GeneratorType;
 import io.cdap.plugin.datagen.generator.Schemas;
@@ -42,6 +43,7 @@ import io.cdap.plugin.datagen.generator.SequentialIntGenerator;
 import io.cdap.plugin.datagen.generator.SequentialLongGenerator;
 import org.junit.Assert;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -59,6 +61,9 @@ import java.util.stream.Collectors;
  * Tests for Data Generator.
  */
 public class DataGeneratorTest extends HydratorTestBase {
+  @ClassRule
+  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
+
   private static final Gson GSON = new Gson();
   private static final ArtifactId APP_ARTIFACT_ID = NamespaceId.DEFAULT.artifact("app", "1.0.0");
   private static final ArtifactSummary APP_ARTIFACT = new ArtifactSummary("app", "1.0.0");


### PR DESCRIPTION
This PR is to resolve log4j vulnerabilities by bumping hadoop and spark dependency versions.
Moreover, the unit test was running into the below error, so to fix the unit test, a ClassRule was added to disable explore which isn't used anyways. 
java.lang.NoClassDefFoundError: org/apache/hadoop/hive/ql/metadata/HiveException